### PR TITLE
Fix issues when running and comparing output on Lustre.

### DIFF
--- a/src/scripts/assembly/assemblyQt.py
+++ b/src/scripts/assembly/assemblyQt.py
@@ -698,6 +698,7 @@ class Ui_Form(object):
 
 				outfile = open(projectName+"_genome.fasta","w")
 				outfile.write(">finalScaffold\n"+finalSequence)
+				outfile.close()
 
 
 

--- a/src/scripts/assembly/utils/mergeQualFilteredMates.py
+++ b/src/scripts/assembly/utils/mergeQualFilteredMates.py
@@ -48,13 +48,13 @@ peculiar2 = loci2Set - loci1Set
 #Write the sorted first fastq file
 print("Writing file ",outfileName1)
 with open(outfileName1,"w") as handle :
-    for locus in lociCommon:
+    for locus in sorted(lociCommon):
         SeqIO.write(loci1[locus],handle,"fastq")
 
 #Write the sorted second fastq file
 print("Writing file ",outfileName2)
 with open(outfileName2,"w") as handle :
-    for locus in lociCommon:
+    for locus in sorted(lociCommon):
         SeqIO.write(loci2[locus],handle,"fastq")
 
 #write singletons


### PR DESCRIPTION
2 changes were required in assembly stage to make it possible to check output when running on Lustre filesystem.

1. Make sure a file is closed to flush contents.
2. When looping over contents of a file make sure we sort the set used to store information since sets are not ordered and different results from runs occur.